### PR TITLE
Rating 'stars' conditional on rating being a number.

### DIFF
--- a/myday.php
+++ b/myday.php
@@ -38,7 +38,6 @@ switch ($mood) {
       	echo "You are " . $mood . ", But we don't support it yet sorry ;(";
 }
 ?>
-
 <html>
 <head>
 <link rel="stylesheet" href="myday.css">
@@ -53,14 +52,10 @@ switch ($mood) {
         <h3><?= $result["name"] ?></h3>
           <p class="result address">Address: <?= $result["address"]?></p>
           <p class="result type">Buisness Type: <?= $result["type"]?></p>
-          <p class="result rating">Rating: <?= $result["rating"]?> stars</p>
+          <p class="result rating">Rating: <?= $result["rating"] ?><?php if (is_numeric($result["rating"])): echo " stars"; endif ?></p>
         </li>
     <?php endforeach ?>
   </ol>
-
-
-
-
 </div> 
 </body>
 </html>


### PR DESCRIPTION
Sometimes you get a rating value of "pass" or "fail" rather than a value out of five. We only want to print ` stars` when it is a number, so this adds in that condition by checking if the value is a number or not.